### PR TITLE
Add address search boxes for start/end

### DIFF
--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -53,6 +53,7 @@ export default class MapContainer extends React.Component {
 		this.loadSnowPlowData = this.loadSnowPlowData.bind(this);
 		this.resetRoute = this.resetRoute.bind(this);
 		this.onStartChoose = this.onStartChoose.bind(this);
+		this.onDestChoose = this.onDestChoose.bind(this);
 		this.onPopupClose = this.onPopupClose.bind(this);
 		this.onMapClick = this.onMapClick.bind(this);
 		this.addMarker = this.addMarker.bind(this);
@@ -150,7 +151,29 @@ export default class MapContainer extends React.Component {
 	
 	onStartChoose(event, value) {
 		if (value != null && this.map.current != null) {
-			this.map.current.setCenter(value.geometry.coordinates)
+			let coords = new maplibregl.LngLat(value.geometry.coordinates[0], value.geometry.coordinates[1]);
+			this.map.current.setCenter(value.geometry.coordinates);
+			console.error(value.geometry)
+			this.setState({
+				hasStart: true,
+				start: coords
+			});
+			if (this.state.hasEnd) {
+				this.getQuery(this.state.start, coords);
+			}
+		}
+	}
+	
+	onDestChoose(event, value) {
+		if (value != null && this.map.current != null) {
+			let coords = new maplibregl.LngLat(value.geometry.coordinates[0], value.geometry.coordinates[1]);
+			this.setState({
+				hasEnd: true,
+				dest: coords
+			});
+			if (this.state.hasStart) {
+				this.getQuery(this.state.start, coords);
+			}
 		}
 	}
 	
@@ -411,7 +434,10 @@ export default class MapContainer extends React.Component {
 						<BikelyPopup lngLat={this.state.popupCoords} onClose={this.onPopupClose} point={this.state.popupPoint} />)}
 					{this.state.isSnowPlowPopupOpen && (
 						<SnowPlowPopup lngLat={this.state.popupCoords} onClose={this.onPopupClose} point={this.state.popupPoint} />)}
-					<SearchField onChoose={this.onStartChoose} />
+					<div id="searchFields" >
+						<SearchField onChoose={this.onStartChoose} labelText="Fra" />
+						<SearchField onChoose={this.onDestChoose} labelText="Til" />
+					</div>
 					<Menu reset={this.resetRoute} />
 					<Backdrop
 						sx={{ color: '#fff', zIndex: (theme) => theme.zIndex.drawer + 1 }}

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -153,13 +153,12 @@ export default class MapContainer extends React.Component {
 		if (value != null && this.map.current != null) {
 			let coords = new maplibregl.LngLat(value.geometry.coordinates[0], value.geometry.coordinates[1]);
 			this.map.current.setCenter(value.geometry.coordinates);
-			console.error(value.geometry)
 			this.setState({
 				hasStart: true,
 				start: coords
 			});
 			if (this.state.hasEnd) {
-				this.getQuery(this.state.start, coords);
+				this.getQuery(coords, this.state.dest);
 			}
 		}
 	}

--- a/src/components/SearchField.js
+++ b/src/components/SearchField.js
@@ -1,7 +1,7 @@
 import {Autocomplete, debounce, TextField} from "@mui/material";
 import React, {useState} from "react";
 
-export default function SearchField({ onChoose }) {
+export default function SearchField({ onChoose, labelText }) {
 	let [options, setOptions] = useState([]);
 	
 	const inputChanged = (event, value) => {
@@ -36,7 +36,7 @@ export default function SearchField({ onChoose }) {
 		              getOptionLabel={(option) => option.properties.label || ""}
 		              onInputChange={debounce(inputChanged, 200)}
 		              sx={{ width: 300 }}
-		              renderInput={(params) => <TextField {...params} label="Search for a place" />}
+		              renderInput={(params) => <TextField {...params} label={labelText} />}
 		              onChange={onChoose}
 		/>
 	);

--- a/src/styles/map.css
+++ b/src/styles/map.css
@@ -11,11 +11,15 @@
     height: 100%;
 }
 
-.autocomplete {
-    background-color: #fff;
+#searchFields {
     position: relative;
     top: 10px;
     left: 50px;
+    display: flex;
+}
+
+.autocomplete {
+    background-color: #fff;
 }
 
 .menu {

--- a/src/styles/map.css
+++ b/src/styles/map.css
@@ -16,13 +16,12 @@
         position: relative;
         top: 10px;
         left: 50px;
-        display: flex;
     }
 
     .menu {
         position: absolute;
-        top: 75px;
-        left: 45px;
+        top: 145px;
+        left: 50px;
     }
 
     .maplibregl-legend-list {
@@ -61,10 +60,11 @@
 
 .autocomplete {
     background-color: #fff;
+    margin-bottom: 5px;
 }
 
 .menu button {
-    margin: 5px;
+    margin-right: 5px;
 }
 
 .maplibregl-legend-list {

--- a/src/styles/map.css
+++ b/src/styles/map.css
@@ -11,23 +11,56 @@
     height: 100%;
 }
 
-#searchFields {
-    position: relative;
-    top: 10px;
-    left: 50px;
-    display: flex;
+@media only screen and (min-width: 900px) {
+    #searchFields {
+        position: relative;
+        top: 10px;
+        left: 50px;
+        display: flex;
+    }
+
+    .menu {
+        position: absolute;
+        top: 75px;
+        left: 45px;
+    }
+
+    .maplibregl-legend-list {
+        width: 200px;
+    }
+}
+
+@media only screen and (max-width: 900px) {
+    #searchFields {
+        position: relative;
+        top: 50px;
+        left: 10px;
+    }
+
+    .menu {
+        position: absolute;
+        top: 185px;
+        left: 10px;
+    }
+
+    .maplibregl-legend-list {
+        width: 180px;
+    }
+}
+
+@media only screen and (max-width: 510px) {
+    .autocomplete {
+        width: 220px !important;
+    }
+}
+
+.menu {
+    z-index: 1;
+    padding: 0;
 }
 
 .autocomplete {
     background-color: #fff;
-}
-
-.menu {
-    position: absolute;
-    top: 75px;
-    left: 45px;
-    z-index: 1;
-    padding: 0;
 }
 
 .menu button {
@@ -35,7 +68,6 @@
 }
 
 .maplibregl-legend-list {
-    width: 200px;
     overflow-y: auto;
     max-height: calc(100vh * 0.7);
 }


### PR DESCRIPTION
Added search boxes for start and destination.

When start is selected, the map jumps to the selected place and the start marker is placed. When the destination is selected, the destination marker is placed.

When both start and destination is selected and the markers are placed, the route is requested and computed. It doesn't matter whether the start or the destination was chosen first.

![Képernyőkép_2023-03-02_20-46-56](https://user-images.githubusercontent.com/46535522/222536249-60d3c8fe-368a-4f1d-82ed-bc47fd2225ef.png)

Concerning #8 on the mobile view it is even worse now... So I added some media queries, until 430px it looks ok, but we need to make the legend minimizable below that.

![Képernyőkép_2023-03-02_21-31-55](https://user-images.githubusercontent.com/46535522/222545154-a5eb4c47-7581-475c-9c5d-68c339ac01dd.png)


Closes #2