### PR TITLE
Norwegian text in "Reset route" and "Help"

### DIFF
--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -16,11 +16,10 @@ class Menu extends React.Component {
 			top: '50%',
 			left: '50%',
 			transform: 'translate(-50%, -50%)',
-			width: 400,
 			bgcolor: 'background.paper',
-			border: '2px solid #000',
+			border: '1px solid #000',
 			boxShadow: 24,
-			p: 4,
+			p: 2,
 		};
 	}
 	
@@ -43,26 +42,28 @@ class Menu extends React.Component {
 	render() {
 		return (
 			<div className="menu">
-				<Button id={"reset"} variant={'contained'} size={'small'} onClick={this.resetRoute}>Reset route</Button>
-				<Button id={"show-help"} variant={'contained'} size={'small'} onClick={this.toggleHelpPopup}>Help</Button>
+				<Button id={"reset"} variant={'contained'} size={'small'} onClick={this.resetRoute}>Nullstill rute</Button>
+				<Button id={"show-help"} variant={'contained'} size={'small'} onClick={this.toggleHelpPopup}>Hjelp</Button>
 				
-				<Modal id={"help"} open={this.state.isHelpOpen} aria-labelledby="modal-modal-title"
-				       aria-describedby="modal-modal-description"
+				<Modal id={"help"} open={this.state.isHelpOpen} aria-labelledby="modal-title"
 				       onClose={this.closeHelpPopup}>
-					<Box sx={this.style}>
-						<Typography id="modal-modal-title" variant="h6" component="h2">
-							Bicycle route planning prototype
+					<Box sx={this.style} className="modal-box">
+						<Typography id="modal-title" variant="h6" component="h2">
+							Sykkelkart- og sykkelvei-pilot 2021-2023
 						</Typography>
-						<Typography id="modal-modal-description" sx={{ mt: 2 }}>
-							<p>
-								Please click on the map once to select the start of the route and click a second time to select its destination.
-							</p>
-							<p>
-								When the route is displayed you can drag the markers to change the start or destination.
-							</p>
-							<p>
-								<a href="./?from=59.72785%2C10.20643&to=59.75285%2C10.16012">Show example</a>
-							</p>
+						<Typography className="modal-description" sx={{ mt: 2 }} align="justify" >
+							Få en anbefalt god sykkelrute fra hvilken som helst vei eller skogssti i Norge til et sted du ønsker å reise til. Klikk først på hvor du vil reise fra, og klikk igjen for å velge destinasjon.
+							Start- og stoppmarkørene kan også da flyttes til nye steder. Ruteforslaget vil da oppdateres. <a href="./?from=59.71982%2C10.25855&to=59.74460%2C10.20589#13.35/59.73268/10.22634">Vis eksempel.</a>
+						</Typography>
+						<Typography className="modal-description" sx={{ mt: 2 }} align="justify" >
+							Kartløsningen viser også sykkelruter, sykkelanlegg, parkering, offentlige servicestasjoner og annen relevant informasjon for syklister. Ønsker du bidra med data eller har spørsmål, ta kontakt med post(krøllalfa)buskerudbyen(punktum)no.
+						</Typography>
+						<Typography className="modal-description" sx={{ mt: 2 }} align="justify" >
+							Løsningen er utarbeidet i samarbeid med <a href="https://developer.entur.org/">Entur</a>,
+							og med midler fra <a href="https://www.buskerudbyen.no/">Buskerudbyen</a>, <a href="https://bymiljopakken.no/">Bymiljøpakken</a> / <a href="https://www.kolumbus.no/">Kolumbus</a>,
+							&nbsp;<a href="https://viken.no/">Viken fylkeskommune</a> og <a href="https://www.vegvesen.no/fag/trafikk/its-portalen/its-i-statens-vegvesen/">Statens vegvesen (ITS-programmet)</a>.
+							Takk også til alle frivillige bidragsytere av <a href="https://wiki.openstreetmap.org/wiki/No:Main_Page">OpenStreetMap</a> og alle åpne kartdata fra Statens vegvesen og Kartverket.
+							Løsningen utviklet av <a href="https://leonard.io/">Leonard</a> og <a href="https://github.com/Beck-berry">Beck-berry</a>. Sist oppdatert mars 2023.
 						</Typography>
 					</Box>
 				</Modal>

--- a/src/styles/map.css
+++ b/src/styles/map.css
@@ -45,11 +45,19 @@
     .maplibregl-legend-list {
         width: 180px;
     }
+
+    .modal-box {
+        width: 400px;
+    }
 }
 
 @media only screen and (max-width: 510px) {
     .autocomplete {
         width: 220px !important;
+    }
+
+    .modal-box {
+        width: 250px;
     }
 }
 
@@ -65,6 +73,12 @@
 
 .menu button {
     margin-right: 5px;
+}
+
+.modal-box {
+    word-wrap: break-word;
+    overflow-y: auto;
+    max-height: 80%;
 }
 
 .maplibregl-legend-list {


### PR DESCRIPTION
Renamed the buttons and changed the text in the "Help" popup as requested in #9.

On PC:
![Képernyőkép_2023-03-11_14-00-59](https://user-images.githubusercontent.com/46535522/224486082-46cd6ea4-ad55-4c89-815d-24b13ce1928a.png)

On smaller screens (popup height goes up to 80% of the screen):
![Képernyőkép_2023-03-11_14-01-30](https://user-images.githubusercontent.com/46535522/224486092-44227172-c859-49ca-9078-eda2f651ebd4.png)

Closes #9