### PR TITLE
Add privacy policy information

### DIFF
--- a/src/components/AttributionPanel.js
+++ b/src/components/AttributionPanel.js
@@ -32,7 +32,7 @@ class AttributionPanel extends React.Component {
 			<div className="maplibregl-ctrl maplibregl-ctrl-attrib mapboxgl-ctrl mapboxgl-ctrl-attrib">
 				<Button variant="text" size="small" onClick={this.togglePolicyPopup}>Personvern</Button>
 				<a href="https://www.maptiler.com/copyright/" target="_blank" rel="noreferrer">&copy; MapTiler </a>
-				<a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noreferrer">&copy; OpenStreetMap bidragsytere</a>
+				<a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noreferrer">&copy; OpenStreetMaps bidragsytere</a>
 				
 				<Modal id={"privacy-policy"} open={this.state.isPolicyPopup} onClose={this.togglePolicyPopup} aria-labelledby="modal-title">
 					<Box sx={this.style} className="modal-box">

--- a/src/components/AttributionPanel.js
+++ b/src/components/AttributionPanel.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import {Box, Button, Modal, Typography} from "@mui/material";
+
+class AttributionPanel extends React.Component {
+	constructor(props) {
+		super(props);
+		this.state = {
+			isPolicyPopup: false
+		};
+		this.togglePolicyPopup = this.togglePolicyPopup.bind(this);
+		
+		this.style = {
+			position: 'absolute',
+			top: '50%',
+			left: '50%',
+			transform: 'translate(-50%, -50%)',
+			bgcolor: 'background.paper',
+			border: '1px solid #000',
+			boxShadow: 24,
+			p: 2,
+		};
+	}
+	
+	togglePolicyPopup() {
+		this.setState(prevState => ({
+			isPolicyPopup: !prevState.isPolicyPopup,
+		}));
+	}
+	
+	render() {
+		return (
+			<div className="maplibregl-ctrl maplibregl-ctrl-attrib mapboxgl-ctrl mapboxgl-ctrl-attrib">
+				<Button variant="text" size="small" onClick={this.togglePolicyPopup}>Personvern</Button>
+				<a href="https://www.maptiler.com/copyright/" target="_blank" rel="noreferrer">&copy; MapTiler </a>
+				<a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noreferrer">&copy; OpenStreetMap bidragsytere</a>
+				
+				<Modal id={"privacy-policy"} open={this.state.isPolicyPopup} onClose={this.togglePolicyPopup} aria-labelledby="modal-title">
+					<Box sx={this.style} className="modal-box">
+						<Typography id="modal-title" variant="h5" component="h1">
+							Personopplysninger og personvern
+						</Typography>
+						<Typography className="modal-description" sx={{ mt: 2 }} align="justify" >
+							Buskerudbyen og Drammen kommune er ansvarlig for tjenesten som leveres her på Sykkelveier.no (og <a href="https://leonard.io/cycling-norway/">leonard.io/cycling-norway/</a>). Se websiden <a href="https://www.drammen.kommune.no/">drammen.kommune.no</a> for mer informasjon om personvern og personvernombud. Du kan også ta kontakt med oss på post @ buskerudbyen.no.
+						</Typography>
+						<Typography variant="h6" component="h2" sx={{ mt: 2 }}>
+							Hvilken informasjon lagres?
+						</Typography>
+						<Typography className="modal-description" sx={{ mt: 2 }} align="justify" >
+							Sykkelveier.no lagrer ingen personinformasjon om brukeren. For logger, lagres IP-adresser som besøker siden.
+						</Typography>
+						<Typography variant="h6" component="h2" sx={{ mt: 2 }}>
+							Videresending av informasjon
+						</Typography>
+						<Typography className="modal-description" sx={{ mt: 2 }} align="justify" >
+							Alle søk på adresser eller steder i Norge blir sendt videre til Entur sitt Nasjonalt reisesøk-API. Behandling av disse dataene er dekket av <a href="https://om.entur.no/personvern/">Enturs personvernregler</a>.
+						</Typography>
+						<Typography variant="h6" component="h2" sx={{ mt: 2 }}>
+							Hvordan sikrer vi dine personopplysninger?
+						</Typography>
+						<Typography className="modal-description" sx={{ mt: 2 }} align="justify" >
+							Sykkelveier følger kravene til informasjonssikkerhet i gjeldende personvernlovgivning.
+							Vi har etablert rutiner og tiltak for å sikre at uvedkommende ikke får tilgang til løsningen. Tiltakene inkluderer blant annet jevnlige risikovurderinger, tilpassede og oppdaterte tekniske systemer og fysiske prosedyrer for å ivareta informasjonssikkerheten.
+						</Typography>
+						<Typography variant="h6" component="h2" sx={{ mt: 2 }}>
+							Din posisjon
+						</Typography>
+						<Typography className="modal-description" sx={{ mt: 2 }} align="justify" >
+							Søket med «Find my location» skjer kun i nettleseren, så posisjonen blir ikke sendt til serveren før man søker på en rute med GPS-posisjon aktiv. Posisjonen finner man ved hjelp av telefonens GPS-funksjon, WiFi-tilkoblinger, IP-adresser, RFID, Bluetooth, MAC-adresser og GSM/CDMA-celle-ID. Om nettleseren vil vite hvor man er, spør den om lov først. Du kan alltid regulere denne tilgangen i nettleserens innstillinger.
+						</Typography>
+						<Typography className="modal-description" sx={{ mt: 2 }} align="justify" >
+							Personvernerklæringen ble senest oppdatert 3. mai 2023.
+						</Typography>
+					</Box>
+				</Modal>
+			</div>
+		);
+	}
+}
+
+export default AttributionPanel;

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -3,7 +3,7 @@ import maplibregl from "maplibre-gl";
 import '../styles/map.css';
 import 'maplibre-gl/dist/maplibre-gl.css'
 import Menu from './Menu';
-import Map, {AttributionControl, GeolocateControl, Layer, Marker, NavigationControl, Source} from "react-map-gl";
+import Map, {GeolocateControl, Layer, Marker, NavigationControl, Source} from "react-map-gl";
 import {Backdrop, CircularProgress} from "@mui/material";
 import polyline from '@mapbox/polyline';
 import BikelyPopup from "./BikelyPopup";
@@ -11,6 +11,7 @@ import {MaplibreLegendControl} from "@watergis/maplibre-gl-legend";
 import SportsScoreIcon from '@mui/icons-material/SportsScore';
 import SnowPlowPopup from "./SnowPlowPopup";
 import RoutingSidebar from "./RoutingSidebar";
+import AttributionPanel from "./AttributionPanel";
 
 const INITIAL_LAT = 59.7390;
 const INITIAL_LON = 10.1878;
@@ -93,14 +94,6 @@ export default class MapContainer extends React.Component {
 		this.setState({
 			searchFieldsOpen: window.innerWidth > 450
 		});
-	}
-	
-	getAttributionText() {
-		return "<p>" +
-			"<a href=\"https://www.maptiler.com/copyright/\" target=\"_blank\">&copy; MapTiler</a>" +
-			"&#32;&#32;&#32;" +
-			"<a href=\"https://www.openstreetmap.org/copyright\" target=\"_blank\">&copy; Map data from OpenStreetMap</a>" +
-			"</p>";
 	}
 	
 	addLegend() {
@@ -520,8 +513,9 @@ export default class MapContainer extends React.Component {
 						trackUserLocation={false}
 					/>
 					<NavigationControl position="bottom-left" showCompass showZoom visualizePitch />
-					<AttributionControl position="bottom-right" compact={false}
-					                    customAttribution={this.getAttributionText()} />
+					<div className="maplibregl-ctrl-bottom-right mapboxgl-ctrl-bottom-right">
+						<AttributionPanel />
+					</div>
 					{this.state.hasStart && (
 						<Marker
 							longitude={this.state.start?.lng}

--- a/src/styles/map.css
+++ b/src/styles/map.css
@@ -166,3 +166,12 @@
     stroke: gray;
     stroke-opacity: 0.5;
 }
+
+.maplibregl-ctrl-attrib a, .maplibregl-ctrl-attrib button {
+    color: rgba(0, 0, 0, .75);
+    text-decoration: none;
+    letter-spacing: normal;
+    text-transform: none;
+    font-size: 12px;
+    font-family: 'Helvetica Neue', 'Arial', serif;
+}


### PR DESCRIPTION
Changes:
* created our own `AttributionPanel` to be able to contol the popup via state
* added `Personvern` as a button to the attribution panel
* renamed `OpenStreetMap` link
* created privacy policy popup

![Képernyőkép_2023-05-14_16-44-54](https://github.com/buskerudbyen/cycling-norway/assets/46535522/adc98856-793a-4e66-a424-3ed8db91e005)

Tested also on mobile (Android, Chrome): <details>
  <summary>screenshot</summary>

  ![Screenshot_2023-05-14-16-29-19-825_com.android.chrome.png](https://github.com/buskerudbyen/cycling-norway/assets/46535522/d7c2cb7a-a24e-4481-b386-a3e88749a5ea)
</datails>

Closes #28