### PR TITLE
Tunnel information popup

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@watergis/maplibre-gl-legend": "1.2.8",
     "gl-matrix": "3.4.3",
     "maplibre-gl": "2.4.0",
+    "moment": "^2.29.4",
     "opening_hours": "^3.8.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
     "@watergis/maplibre-gl-legend": "1.2.8",
     "gl-matrix": "3.4.3",
     "maplibre-gl": "2.4.0",
+    "opening_hours": "^3.8.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-error-overlay": "6.0.9",
     "react-map-gl": "^7.0.21",
     "react-scripts": "4.0.3",
+    "simple-opening-hours": "^0.1.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -13,6 +13,7 @@ import SnowPlowPopup from "./SnowPlowPopup";
 import RoutingSidebar from "./RoutingSidebar";
 import AttributionPanel from "./AttributionPanel";
 import SykkelHotelPopup from "./SykkelHotelPopup";
+import TunnelPopup from "./TunnelPopup";
 
 const INITIAL_LAT = 59.7390;
 const INITIAL_LON = 10.1878;
@@ -54,6 +55,7 @@ export default class MapContainer extends React.Component {
 			isBikelyPopupOpen: false,
 			isSnowPlowPopupOpen: false,
 			isSykkelhotelPopupOpen: false,
+			isTunnelPopupOpen: false,
 			popupCoords: null,
 			popupPoint: null,
 			searchFieldsOpen: window.innerWidth >= 450,
@@ -227,6 +229,9 @@ export default class MapContainer extends React.Component {
 		const snowPlowFeatures = this.map.current.queryRenderedFeatures(event.point, {
 			layers: ["poi-snow-plow-warn", "poi-snow-plow-ok", "poi-snow-plow-snow", "poi-snow-plow-snow-border"]
 		});
+		const tunnelFeatures = this.map.current.queryRenderedFeatures(event.point, {
+			layers: ["tunnel-conditional"]
+		});
 		if (bikelyFeatures.length > 0) {
 			const feature = bikelyFeatures[0].properties;
 			this.setState({
@@ -242,6 +247,7 @@ export default class MapContainer extends React.Component {
 				isSnowPlowPopupOpen: false,
 				isBikelyPopupOpen: false,
 				isSykkelhotelPopupOpen: true,
+				isTunnelPopupOpen: false,
 				popupCoords: event.lngLat,
 				popupPoint: feature
 			});
@@ -251,6 +257,17 @@ export default class MapContainer extends React.Component {
 				isSnowPlowPopupOpen: true,
 				isBikelyPopupOpen: false,
 				isSykkelhotelPopupOpen: false,
+				isTunnelPopupOpen: false,
+				popupCoords: event.lngLat,
+				popupPoint: feature
+			});
+		} else if (tunnelFeatures.length > 0) {
+			const feature = tunnelFeatures[0].properties;
+			this.setState({
+				isSnowPlowPopupOpen: false,
+				isBikelyPopupOpen: false,
+				isSykkelhotelPopupOpen: false,
+				isTunnelPopupOpen: true,
 				popupCoords: event.lngLat,
 				popupPoint: feature
 			});
@@ -264,6 +281,7 @@ export default class MapContainer extends React.Component {
 			isBikelyPopupOpen: false,
 			isSnowPlowPopupOpen: false,
 			isSykkelhotelPopupOpen: false,
+			isTunnelPopupOpen: false,
 			popupPoint: null
 		})
 	}
@@ -519,6 +537,8 @@ export default class MapContainer extends React.Component {
 						<SykkelHotelPopup lngLat={this.state.popupCoords} onClose={this.onPopupClose} point={this.state.popupPoint} />)}
 					{this.state.isSnowPlowPopupOpen && (
 						<SnowPlowPopup lngLat={this.state.popupCoords} onClose={this.onPopupClose} point={this.state.popupPoint} />)}
+					{this.state.isTunnelPopupOpen && (
+						<TunnelPopup lngLat={this.state.popupCoords} onClose={this.onPopupClose} point={this.state.popupPoint} />)}
 					<Menu reset={this.resetRoute} toggleSearch={this.toggleSearchFields} />
 					<RoutingSidebar chooseStart={this.onStartChoose}
 					                chooseDest={this.onDestChoose}

--- a/src/components/TunnelPopup.js
+++ b/src/components/TunnelPopup.js
@@ -3,16 +3,18 @@ import {Popup} from "react-map-gl";
 import opening_hours from "opening_hours";
 import {SimpleOpeningHours} from "simple-opening-hours";
 import {Table, TableBody, TableCell, TableRow, Typography} from "@mui/material";
+import moment from "moment";
+import 'moment/locale/nb';
 
-const DAYS = {
-	"Mo": "mandag",
-	"Tu": "tirsdag",
-	"We": "onsdag",
-	"Th": "torsdag",
-	"Fr": "fredag",
-	"Sa": "lørdag",
-	"Su": "søndag"
-}
+const DAYS = new Map([
+	["mo", "mandag"],
+	["tu", "tirsdag"],
+	["we", "onsdag"],
+	["th", "torsdag"],
+	["fr", "fredag"],
+	["sa", "lørdag"],
+	["su", "søndag"]
+]);
 
 class TunnelPopup extends React.Component {
 	
@@ -26,7 +28,7 @@ class TunnelPopup extends React.Component {
 		}
 		
 		if (oh === "24/7") {
-			return startString + DAYS['Mo'] + " til " + DAYS['Su'] + "." ;
+			return startString + DAYS['mo'] + " til " + DAYS['su'] + "." ;
 		}
 		
 		// display opening hours for the next 24 hours
@@ -41,7 +43,8 @@ class TunnelPopup extends React.Component {
 	}
 	
 	getTime(fullDate) {
-		return fullDate.toLocaleTimeString();
+		moment.locale('nb');
+		return moment(fullDate).format('LT');
 	}
 	
 	getMessage(point) {
@@ -84,50 +87,34 @@ class TunnelPopup extends React.Component {
 		// If there are multiple rules.
 		if (oh.split(";").length - 1 > 1) {
 			const ohObject = new SimpleOpeningHours(oh);
-			return ohObject.getTable();
+			const openingHours = ohObject.getTable();
+			
+			let rows = [];
+			DAYS.forEach((value, key) => {
+				rows.push(
+					<TableRow>
+						<TableCell>{value}</TableCell>
+						<TableCell>{openingHours[key]}</TableCell>
+					</TableRow>
+				);
+			})
+			
+			return (
+				<Table padding={'none'} size={'small'}>
+					<TableBody>
+						{rows}
+					</TableBody>
+				</Table>
+			);
 		}
 		return null;
 	}
 	
 	render() {
-		const openingHours = this.getOpeningHoursTable(this.props.point)
 		return (
 			<Popup latitude={this.props.lngLat.lat} longitude={this.props.lngLat.lng} onClose={this.props.onClose}>
 				<Typography gutterBottom={true}>{this.getMessage(this.props.point)}</Typography>
-				{openingHours != null &&
-					<Table padding={'none'} size={'small'}>
-						<TableBody>
-							<TableRow>
-								<TableCell>{DAYS['Mo']}</TableCell>
-								<TableCell>{openingHours['mo']}</TableCell>
-							</TableRow>
-							<TableRow>
-								<TableCell>{DAYS['Tu']}</TableCell>
-								<TableCell>{openingHours['tu']}</TableCell>
-							</TableRow>
-							<TableRow>
-								<TableCell>{DAYS['We']}</TableCell>
-								<TableCell>{openingHours['we']}</TableCell>
-							</TableRow>
-							<TableRow>
-								<TableCell>{DAYS['Th']}</TableCell>
-								<TableCell>{openingHours['th']}</TableCell>
-							</TableRow>
-							<TableRow>
-								<TableCell>{DAYS['Fr']}</TableCell>
-								<TableCell>{openingHours['fr']}</TableCell>
-							</TableRow>
-							<TableRow>
-								<TableCell>{DAYS['Sa']}</TableCell>
-								<TableCell>{openingHours['sa']}</TableCell>
-							</TableRow>
-							<TableRow>
-								<TableCell>{DAYS['Su']}</TableCell>
-								<TableCell>{openingHours['su']}</TableCell>
-							</TableRow>
-						</TableBody>
-					</Table>
-				}
+				{this.getOpeningHoursTable(this.props.point)}
 			</Popup>
 		);
 	}

--- a/src/components/TunnelPopup.js
+++ b/src/components/TunnelPopup.js
@@ -1,5 +1,8 @@
 import React from "react";
 import {Popup} from "react-map-gl";
+import opening_hours from "opening_hours";
+import {SimpleOpeningHours} from "simple-opening-hours";
+import {Table, TableBody, TableCell, TableRow, Typography} from "@mui/material";
 
 const DAYS = {
 	"Mo": "mandag",
@@ -13,44 +16,118 @@ const DAYS = {
 
 class TunnelPopup extends React.Component {
 	
-	parseOpeningHours(oh) {
+	parseOpeningHours(oh, startString) {
 		if (oh === undefined) {
 			return;
 		}
 		
-		let parts = [];
-		parts[0] = oh.split("-")[0]; // from day
-		parts[1] = oh.split("-")[1].split(" ")[0]; // to day
-		parts[2] = oh.split(" ")[1]; // hours
-		return parts;
+		if (oh.startsWith('no')) {
+			return startString + oh.split("(")[1].split(")")[0];
+		}
+		
+		if (oh === "24/7") {
+			return startString + DAYS['Mo'] + " til " + DAYS['Su'] + "." ;
+		}
+		
+		// display opening hours for the next 24 hours
+		const ohObject = new opening_hours(oh);
+		const today = new Date();
+		const tomorrow = new Date();
+		today.setHours(0, 0, 0, 0);
+		tomorrow.setDate(today.getDate() + 1);
+		tomorrow.setHours(0, 0, 0, 0);
+		const intervals = ohObject.getOpenIntervals(today, tomorrow);
+		return startString + this.getTime(intervals[0][0]) + " til " + this.getTime(intervals[0][1]) + ".";
+	}
+	
+	getTime(fullDate) {
+		return fullDate.toLocaleTimeString();
 	}
 	
 	getMessage(point) {
 		if (point.hasOwnProperty('opening_hours')) {
-			let parts = this.parseOpeningHours(point['opening_hours']);
-			return parts !== undefined ? "Tunnel åpen " + DAYS[parts[0]] + " til " + DAYS[parts[1]] + " kl. " + parts[2] : '';
+			return this.parseOpeningHours(point['opening_hours'], "Tunnel åpen ");
 		}
 		
 		if (point.hasOwnProperty('lit')) {
 			if (point['lit'] === 'no') {
 				return "Tunnel uten lys.";
+			} else if (point['lit'] === '24/7') {
+				return "Tunnel med lys.";
 			} else {
-				let parts = this.parseOpeningHours(point['lit']);
-				return parts !== undefined ? "Tunnel med lys kun " + DAYS[parts[0]] + " til " + DAYS[parts[1]] + " kl. " + parts[2] : '';
+				return this.parseOpeningHours(point['lit'], "Tunnel med lys kun ");
 			}
 		}
 		
 		if (point.hasOwnProperty('conditional_bike')) {
-			let oh = point['conditional_bike'];
-			oh = oh.split("(")[1].split(")")[0];
-			return "Anlegg stengt kl. " + oh;
+			return this.parseOpeningHours(point['conditional_bike'], "Anlegg stengt kl. ");
 		}
 	}
 	
+	getOpeningHoursValue(point) {
+		if (point.hasOwnProperty('opening_hours')) {
+			return point['opening_hours'];
+		}
+		
+		if (point.hasOwnProperty('lit')) {
+			return point['lit'];
+		}
+		
+		if (point.hasOwnProperty('conditional_bike')) {
+			return point['conditional_bike'];
+		}
+	}
+	
+	getOpeningHoursTable(point) {
+		const oh = this.getOpeningHoursValue(point);
+		
+		// If there are multiple rules.
+		if (oh.split(";").length - 1 > 1) {
+			const ohObject = new SimpleOpeningHours(oh);
+			return ohObject.getTable();
+		}
+		return null;
+	}
+	
 	render() {
+		const openingHours = this.getOpeningHoursTable(this.props.point)
 		return (
 			<Popup latitude={this.props.lngLat.lat} longitude={this.props.lngLat.lng} onClose={this.props.onClose}>
-				<div>{this.getMessage(this.props.point)}</div>
+				<Typography gutterBottom={true}>{this.getMessage(this.props.point)}</Typography>
+				{openingHours != null &&
+					<Table padding={'none'} size={'small'}>
+						<TableBody>
+							<TableRow>
+								<TableCell>{DAYS['Mo']}</TableCell>
+								<TableCell>{openingHours['mo']}</TableCell>
+							</TableRow>
+							<TableRow>
+								<TableCell>{DAYS['Tu']}</TableCell>
+								<TableCell>{openingHours['tu']}</TableCell>
+							</TableRow>
+							<TableRow>
+								<TableCell>{DAYS['We']}</TableCell>
+								<TableCell>{openingHours['we']}</TableCell>
+							</TableRow>
+							<TableRow>
+								<TableCell>{DAYS['Th']}</TableCell>
+								<TableCell>{openingHours['th']}</TableCell>
+							</TableRow>
+							<TableRow>
+								<TableCell>{DAYS['Fr']}</TableCell>
+								<TableCell>{openingHours['fr']}</TableCell>
+							</TableRow>
+							<TableRow>
+								<TableCell>{DAYS['Sa']}</TableCell>
+								<TableCell>{openingHours['sa']}</TableCell>
+							</TableRow>
+							<TableRow>
+								<TableCell>{DAYS['Su']}</TableCell>
+								<TableCell>{openingHours['su']}</TableCell>
+							</TableRow>
+						</TableBody>
+					</Table>
+				}
 			</Popup>
 		);
 	}

--- a/src/components/TunnelPopup.js
+++ b/src/components/TunnelPopup.js
@@ -1,0 +1,60 @@
+import React from "react";
+import {Popup} from "react-map-gl";
+
+const DAYS = {
+	"Mo": "mandag",
+	"Tu": "tirsdag",
+	"We": "onsdag",
+	"Th": "torsdag",
+	"Fr": "fredag",
+	"Sa": "lørdag",
+	"Su": "søndag"
+}
+
+class TunnelPopup extends React.Component {
+	
+	parseOpeningHours(oh) {
+		if (oh === undefined) {
+			return;
+		}
+		
+		let parts = [];
+		parts[0] = oh.split("-")[0]; // from day
+		parts[1] = oh.split("-")[1].split(" ")[0]; // to day
+		parts[2] = oh.split(" ")[1]; // hours
+		return parts;
+	}
+	
+	getMessage(point) {
+		if (point.hasOwnProperty('opening_hours')) {
+			let parts = this.parseOpeningHours(point['opening_hours']);
+			return parts !== undefined ? "Tunnel åpen " + DAYS[parts[0]] + " til " + DAYS[parts[1]] + " kl. " + parts[2] : '';
+		}
+		
+		if (point.hasOwnProperty('lit')) {
+			if (point['lit'] === 'no') {
+				return "Tunnel uten lys.";
+			} else {
+				let parts = this.parseOpeningHours(point['lit']);
+				return parts !== undefined ? "Tunnel med lys kun " + DAYS[parts[0]] + " til " + DAYS[parts[1]] + " kl. " + parts[2] : '';
+			}
+		}
+		
+		if (point.hasOwnProperty('conditional_bike')) {
+			let oh = point['conditional_bike'];
+			oh = oh.split("(")[1].split(")")[0];
+			return "Anlegg stengt kl. " + oh;
+		}
+	}
+	
+	render() {
+		return (
+			<Popup latitude={this.props.lngLat.lat} longitude={this.props.lngLat.lng} onClose={this.props.onClose}>
+				<div>{this.getMessage(this.props.point)}</div>
+			</Popup>
+		);
+	}
+	
+}
+
+export default TunnelPopup;


### PR DESCRIPTION
## Changes
If the user clicks on [the previously added i icon](https://github.com/buskerudbyen/proposal-visualizer/pull/8), a popup shows up and gives information about the opening hours / lit hours of the tunnel.

If the schedule is the same every day, there is only one line which displays:
![image](https://github.com/buskerudbyen/cycling-norway/assets/46535522/ce39a310-bb7d-4729-b2c3-6c552a12881e)

Otherwise the full timetable is visible and the upper text discribes the actual today's hours:
![image](https://github.com/buskerudbyen/cycling-norway/assets/46535522/7588c665-0509-40bb-9fbf-054da95e4a51)

Closes #25